### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/datav-cli-ui/plugins/naive-ui.ts
+++ b/datav-cli-ui/plugins/naive-ui.ts
@@ -1,5 +1,5 @@
 import { setup } from '@css-render/vue3-ssr'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin(nuxtApp => {
   if (process.server) {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.